### PR TITLE
Eperez dashboard redundancy 179

### DIFF
--- a/eduid_am/user.py
+++ b/eduid_am/user.py
@@ -89,7 +89,7 @@ class User(object):
             test_doc = {'_id': self.get_id()}
             if check_sync:
                 test_doc['modified_ts'] = modified
-            result = request.db.profiles.update(check_doc, update_doc)
+            result = request.db.profiles.update(test_doc, update_doc)
             if result['n'] == 0:
                 raise UserOutOfSync('The user data has been modified '
                                     'since you started editing it.')


### PR DESCRIPTION
Possibility of unconditionally saving the user.

Right now it is used when changing passwords: since the old password must be supplied with the new password, there is no danger of a race condition. Also, we want to only save the passwords, since other attributes might have changed in parallell - thus the `update_doc` new parameter.
