### PR TITLE
Eperez elem init 4

### DIFF
--- a/eduid_am/ams/common.py
+++ b/eduid_am/ams/common.py
@@ -76,7 +76,7 @@ class AttributeFetcher(ABC):
         user = self.private_db.get_user_by_id(user_id)
         logger.debug('User: {} found.'.format(user))
 
-        user_dict = user.to_dict(old_userdb_format=False)
+        user_dict = user.to_dict()
 
         # white list of valid attributes for security reasons
         attributes_set = {}

--- a/eduid_am/common.py
+++ b/eduid_am/common.py
@@ -4,4 +4,5 @@ from typing import Optional
 
 from celery import Celery
 
+
 celery: Optional[Celery] = None

--- a/eduid_am/common.py
+++ b/eduid_am/common.py
@@ -4,5 +4,4 @@ from typing import Optional
 
 from celery import Celery
 
-
 celery: Optional[Celery] = None

--- a/eduid_am/tests/test_am.py
+++ b/eduid_am/tests/test_am.py
@@ -24,8 +24,8 @@ class AmTestUser(eduid_userdb.User):
 
         eduid_userdb.User.__init__(self, data=data, raise_on_unknown=raise_on_unknown, called_directly=called_directly)
 
-    def to_dict(self, old_userdb_format=False):
-        res = eduid_userdb.User.to_dict(self, old_userdb_format=old_userdb_format)
+    def to_dict(self):
+        res = eduid_userdb.User.to_dict(self)
         res['uid'] = self.uid
         return res
 
@@ -63,7 +63,7 @@ class FakeAttributeFetcher(AttributeFetcher):
         # Transfer all attributes except `uid' from the test plugins database.
         # Transform eduPersonPrincipalName on the way to make it clear that the
         # update was done using this code.
-        res = user.to_dict(old_userdb_format=True)
+        res = user.to_dict()
         res['eduPersonPrincipalName'] = "{!s}@eduid.se".format(user.uid)
         del res['uid']
         attributes = {'$set': res}

--- a/eduid_am/tests/test_proofing_fetchers.py
+++ b/eduid_am/tests/test_proofing_fetchers.py
@@ -949,6 +949,7 @@ class AttributeFetcherOrcidTests(AMTestCase):
                         'expires_in': 631138518,
                         'created_by': 'orcid',
                     },
+                    'name': None,
                     'given_name': 'Testaren',
                     'family_name': 'Testsson',
                     'verified': True,

--- a/eduid_am/tests/test_proofing_fetchers.py
+++ b/eduid_am/tests/test_proofing_fetchers.py
@@ -288,7 +288,9 @@ class AttributeFetcherOldToNewUsersTests(AMTestCase):
 
         self.normalize_data(expected['$set']['nins'], fetched['$set']['nins'])
 
-        assert fetched == expected, 'Fetched (old to new) letter proofing data with appended attributes has unexpected data'
+        assert (
+            fetched == expected
+        ), 'Fetched (old to new) letter proofing data with appended attributes has unexpected data'
 
     def convert_and_remove_norEduPersonNIN(self):
         self.user_data.update({'norEduPersonNIN': '123456781235'})
@@ -570,13 +572,14 @@ class AttributeFetcherEmailProofingTests(AMTestCase):
         fetcher.private_db.save(proofing_user)
 
         fetched = fetcher.fetch_attrs(proofing_user.user_id)
-        expected = {'$set': {'mailAliases': [{'email': 'john@example.com', 'verified': True, 'primary': True,}],},}
+        expected = {
+            '$set': {'mailAliases': [{'email': 'john@example.com', 'verified': True, 'primary': True,}],},
+        }
 
         self.normalize_data(expected['$set']['mailAliases'], fetched['$set']['mailAliases'])
 
         self.assertDictEqual(
-            fetched,
-            expected,
+            fetched, expected,
         )
 
     def test_malicious_attributes(self):
@@ -615,13 +618,14 @@ class AttributeFetcherEmailProofingTests(AMTestCase):
         fetcher.private_db.save(proofing_user)
 
         fetched = fetcher.fetch_attrs(proofing_user.user_id)
-        expected = {'$set': {'mailAliases': [{'email': 'john@example.com', 'verified': True, 'primary': True}],},}
+        expected = {
+            '$set': {'mailAliases': [{'email': 'john@example.com', 'verified': True, 'primary': True}],},
+        }
 
         self.normalize_data(expected['$set']['mailAliases'], fetched['$set']['mailAliases'])
 
         self.assertDictEqual(
-            fetched,
-            expected,
+            fetched, expected,
         )
 
 
@@ -650,7 +654,9 @@ class AttributeFetcherPhoneProofingTests(AMTestCase):
         self.fetcher.private_db.save(proofing_user)
         fetched = self.fetcher.fetch_attrs(proofing_user.user_id)
 
-        expected = {'$set': {'phone': [{'verified': True, 'number': '+46700011336', 'primary': True}],},}
+        expected = {
+            '$set': {'phone': [{'verified': True, 'number': '+46700011336', 'primary': True}],},
+        }
 
         self.normalize_data(expected['$set']['phone'], fetched['$set']['phone'])
 

--- a/eduid_am/tests/test_proofing_fetchers.py
+++ b/eduid_am/tests/test_proofing_fetchers.py
@@ -165,6 +165,10 @@ class AttributeFetcherOldToNewUsersTests(AMTestCase):
         fetcher.private_db.save(proofing_user)
 
         actual_update = fetcher.fetch_attrs(proofing_user.user_id)
+        # remove newly added created_ts
+        for nin in actual_update['$set']['nins']:
+            del nin['created_ts']
+
         expected_update = {
             '$set': {
                 "givenName": u"Testaren",
@@ -197,12 +201,15 @@ class AttributeFetcherOldToNewUsersTests(AMTestCase):
                 ],
             },
         }
-        self.assertDictEqual(actual_update, expected_update)
+        assert actual_update == expected_update, 'Fetched (old to new) letter proofing data has unexpected data'
 
         actual_update = fetcher.fetch_attrs(proofing_user.user_id)
+        # remove newly added created_ts
+        for nin in actual_update['$set']['nins']:
+            del nin['created_ts']
 
         # Don't repeat the letter_proofing_data
-        self.assertDictEqual(actual_update, expected_update)
+        assert actual_update == expected_update, 'Fetched (old to new, 2nd time) letter proofing data has unexpected data'
 
         # Adding a new letter_proofing_data
         self.user_data['letter_proofing_data'].append(
@@ -225,6 +232,10 @@ class AttributeFetcherOldToNewUsersTests(AMTestCase):
         fetcher.private_db.save(proofing_user)
 
         actual_update = fetcher.fetch_attrs(proofing_user.user_id)
+        # remove newly added created_ts
+        for nin in actual_update['$set']['nins']:
+            del nin['created_ts']
+
         expected_update = {
             '$set': {
                 "givenName": u"Testaren",
@@ -280,7 +291,7 @@ class AttributeFetcherOldToNewUsersTests(AMTestCase):
             },
         }
 
-        self.assertDictEqual(actual_update, expected_update)
+        assert actual_update == expected_update, 'Fetched (old to new) letter proofing data with appended attributes has unexpected data'
 
     def convert_and_remove_norEduPersonNIN(self):
         self.user_data.update({'norEduPersonNIN': '123456781235'})
@@ -407,6 +418,10 @@ class AttributeFetcherNINProofingTests(AMTestCase):
         fetcher.private_db.save(proofing_user)
 
         actual_update = fetcher.fetch_attrs(proofing_user.user_id)
+        # remove newly added created_ts
+        for nin in actual_update['$set']['nins']:
+            del nin['created_ts']
+
         expected_update = {
             '$set': {
                 "givenName": u"Testaren",
@@ -440,12 +455,15 @@ class AttributeFetcherNINProofingTests(AMTestCase):
             },
         }
 
-        self.assertDictEqual(actual_update, expected_update)
+        assert actual_update == expected_update, 'Fetched letter proofing data has unexpected data'
 
         actual_update = fetcher.fetch_attrs(proofing_user.user_id)
+        # remove newly added created_ts
+        for nin in actual_update['$set']['nins']:
+            del nin['created_ts']
 
         # Don't repeat the letter_proofing_data
-        self.assertDictEqual(actual_update, expected_update)
+        assert actual_update == expected_update, 'Fetched (2nd time) letter proofing data has unexpected data'
 
         # Adding a new letter_proofing_data
         self.user_data['letter_proofing_data'].append(
@@ -468,6 +486,10 @@ class AttributeFetcherNINProofingTests(AMTestCase):
         fetcher.private_db.save(proofing_user)
 
         actual_update = fetcher.fetch_attrs(proofing_user.user_id)
+        # remove newly added created_ts
+        for nin in actual_update['$set']['nins']:
+            del nin['created_ts']
+
         expected_update = {
             '$set': {
                 "givenName": u"Testaren",
@@ -522,8 +544,7 @@ class AttributeFetcherNINProofingTests(AMTestCase):
                 ],
             },
         }
-
-        self.assertDictEqual(actual_update, expected_update)
+        assert actual_update == expected_update, 'Fetched letter proofing data with appended attributes has unexpected data'
 
 
 class AttributeFetcherEmailProofingTests(AMTestCase):
@@ -626,11 +647,14 @@ class AttributeFetcherPhoneProofingTests(AMTestCase):
     def test_existing_user(self):
         proofing_user = ProofingUser.from_dict(self.user_data)
         self.fetcher.private_db.save(proofing_user)
+        fetched = self.fetcher.fetch_attrs(proofing_user.user_id)
+        # remove newly added created_ts
+        for phone in fetched['$set']['phone']:
+            del phone['created_ts']
 
-        self.assertDictEqual(
-            self.fetcher.fetch_attrs(proofing_user.user_id),
-            {'$set': {'phone': [{'verified': True, 'number': '+46700011336', 'primary': True}],},},
-        )
+        expected = {'$set': {'phone': [{'verified': True, 'number': '+46700011336', 'primary': True}],},}
+
+        assert expected == fetched, 'Unexpected data fetched by phone fetcher for existing user'
 
     def test_malicious_attributes(self):
         self.user_data.update(
@@ -643,15 +667,6 @@ class AttributeFetcherPhoneProofingTests(AMTestCase):
 
         with self.assertRaises(UserHasUnknownData):
             self.fetcher.fetch_attrs(user_id)
-
-    def test_fillup_attributes(self):
-        proofing_user = ProofingUser.from_dict(self.user_data)
-        self.fetcher.private_db.save(proofing_user)
-
-        self.assertDictEqual(
-            self.fetcher.fetch_attrs(proofing_user.user_id),
-            {'$set': {'phone': [{'verified': True, 'number': '+46700011336', 'primary': True}],},},
-        )
 
 
 class AttributeFetcherPersonalDataTests(AMTestCase):
@@ -756,8 +771,13 @@ class AttributeFetcherSecurityTests(AMTestCase):
             '$unset': {'terminated': None},
         }
         fetched = self.fetcher.fetch_attrs(security_user.user_id)
-        for cred in fetched['$set']['passwords']:
-            del cred['created_ts']
+        # remove newly added created_ts
+        for pw in fetched['$set']['passwords']:
+            del pw['created_ts']
+        for nin in fetched['$set']['nins']:
+            del nin['created_ts']
+        for phone in fetched['$set']['phone']:
+            del phone['created_ts']
 
         assert fetched == expected, 'Wrong data fetched by the security fetcher'
 
@@ -778,8 +798,13 @@ class AttributeFetcherSecurityTests(AMTestCase):
         self.fetcher.private_db.save(security_user)
 
         fetched = self.fetcher.fetch_attrs(security_user.user_id)
+        # remove newly added created_ts
         for pw in fetched['$set']['passwords']:
             del pw['created_ts']
+        for nin in fetched['$set']['nins']:
+            del nin['created_ts']
+        for phone in fetched['$set']['phone']:
+            del phone['created_ts']
 
         expected = {
             '$set': {
@@ -822,8 +847,13 @@ class AttributeFetcherResetPasswordTests(AMTestCase):
         self.fetcher.private_db.save(reset_password_user)
 
         fetched = self.fetcher.fetch_attrs(reset_password_user.user_id)
+        # remove newly added created_ts
         for pw in fetched['$set']['passwords']:
             del pw['created_ts']
+        for nin in fetched['$set']['nins']:
+            del nin['created_ts']
+        for phone in fetched['$set']['phone']:
+            del phone['created_ts']
 
         expected = {
             '$set': {
@@ -857,8 +887,13 @@ class AttributeFetcherResetPasswordTests(AMTestCase):
         self.fetcher.private_db.save(reset_password_user)
 
         fetched = self.fetcher.fetch_attrs(reset_password_user.user_id)
+        # remove newly added created_ts
         for pw in fetched['$set']['passwords']:
             del pw['created_ts']
+        for nin in fetched['$set']['nins']:
+            del nin['created_ts']
+        for phone in fetched['$set']['phone']:
+            del phone['created_ts']
 
         expected = {
             '$set': {

--- a/eduid_am/tests/test_proofing_fetchers.py
+++ b/eduid_am/tests/test_proofing_fetchers.py
@@ -660,7 +660,7 @@ class AttributeFetcherPhoneProofingTests(AMTestCase):
 
         self.normalize_data(expected['$set']['phone'], fetched['$set']['phone'])
 
-        assert expected == fetched, 'Unexpected data fetched by phone fetcher for existing user'
+        assert fetched == expected, 'Unexpected data fetched by phone fetcher for existing user'
 
     def test_malicious_attributes(self):
         self.user_data.update(
@@ -961,7 +961,7 @@ class AttributeFetcherOrcidTests(AMTestCase):
 
         self.normalize_data([expected['$set']], [fetched['$set']])
 
-        assert expected == fetched
+        assert fetched == expected
 
     def test_malicious_attributes(self):
         self.user_data.update(

--- a/eduid_am/tests/test_proofing_fetchers.py
+++ b/eduid_am/tests/test_proofing_fetchers.py
@@ -164,12 +164,9 @@ class AttributeFetcherOldToNewUsersTests(AMTestCase):
         fetcher = self.af_registry['eduid_letter_proofing']
         fetcher.private_db.save(proofing_user)
 
-        actual_update = fetcher.fetch_attrs(proofing_user.user_id)
-        # remove newly added created_ts
-        for nin in actual_update['$set']['nins']:
-            del nin['created_ts']
+        fetched = fetcher.fetch_attrs(proofing_user.user_id)
 
-        expected_update = {
+        expected = {
             '$set': {
                 "givenName": u"Testaren",
                 "surname": u"Testsson",
@@ -201,15 +198,16 @@ class AttributeFetcherOldToNewUsersTests(AMTestCase):
                 ],
             },
         }
-        assert actual_update == expected_update, 'Fetched (old to new) letter proofing data has unexpected data'
+        self.normalize_data(expected['$set']['nins'], fetched['$set']['nins'])
+
+        assert fetched == expected, 'Fetched (old to new) letter proofing data has unexpected data'
 
         actual_update = fetcher.fetch_attrs(proofing_user.user_id)
-        # remove newly added created_ts
-        for nin in actual_update['$set']['nins']:
-            del nin['created_ts']
+
+        self.normalize_data(expected['$set']['nins'], fetched['$set']['nins'])
 
         # Don't repeat the letter_proofing_data
-        assert actual_update == expected_update, 'Fetched (old to new, 2nd time) letter proofing data has unexpected data'
+        assert fetched == expected, 'Fetched (old to new, 2nd time) letter proofing data has unexpected data'
 
         # Adding a new letter_proofing_data
         self.user_data['letter_proofing_data'].append(
@@ -231,12 +229,9 @@ class AttributeFetcherOldToNewUsersTests(AMTestCase):
         proofing_user = ProofingUser.from_dict(self.user_data)
         fetcher.private_db.save(proofing_user)
 
-        actual_update = fetcher.fetch_attrs(proofing_user.user_id)
-        # remove newly added created_ts
-        for nin in actual_update['$set']['nins']:
-            del nin['created_ts']
+        fetched = fetcher.fetch_attrs(proofing_user.user_id)
 
-        expected_update = {
+        expected = {
             '$set': {
                 "givenName": u"Testaren",
                 "surname": u"Testsson",
@@ -291,7 +286,9 @@ class AttributeFetcherOldToNewUsersTests(AMTestCase):
             },
         }
 
-        assert actual_update == expected_update, 'Fetched (old to new) letter proofing data with appended attributes has unexpected data'
+        self.normalize_data(expected['$set']['nins'], fetched['$set']['nins'])
+
+        assert fetched == expected, 'Fetched (old to new) letter proofing data with appended attributes has unexpected data'
 
     def convert_and_remove_norEduPersonNIN(self):
         self.user_data.update({'norEduPersonNIN': '123456781235'})
@@ -417,12 +414,9 @@ class AttributeFetcherNINProofingTests(AMTestCase):
         fetcher = self.af_registry['eduid_letter_proofing']
         fetcher.private_db.save(proofing_user)
 
-        actual_update = fetcher.fetch_attrs(proofing_user.user_id)
-        # remove newly added created_ts
-        for nin in actual_update['$set']['nins']:
-            del nin['created_ts']
+        fetched = fetcher.fetch_attrs(proofing_user.user_id)
 
-        expected_update = {
+        expected = {
             '$set': {
                 "givenName": u"Testaren",
                 "surname": u"Testsson",
@@ -454,16 +448,16 @@ class AttributeFetcherNINProofingTests(AMTestCase):
                 ],
             },
         }
+        self.normalize_data(expected['$set']['nins'], fetched['$set']['nins'])
 
-        assert actual_update == expected_update, 'Fetched letter proofing data has unexpected data'
+        assert fetched == expected, 'Fetched letter proofing data has unexpected data'
 
-        actual_update = fetcher.fetch_attrs(proofing_user.user_id)
-        # remove newly added created_ts
-        for nin in actual_update['$set']['nins']:
-            del nin['created_ts']
+        fetched = fetcher.fetch_attrs(proofing_user.user_id)
+
+        self.normalize_data(expected['$set']['nins'], fetched['$set']['nins'])
 
         # Don't repeat the letter_proofing_data
-        assert actual_update == expected_update, 'Fetched (2nd time) letter proofing data has unexpected data'
+        assert fetched == expected, 'Fetched (2nd time) letter proofing data has unexpected data'
 
         # Adding a new letter_proofing_data
         self.user_data['letter_proofing_data'].append(
@@ -485,12 +479,9 @@ class AttributeFetcherNINProofingTests(AMTestCase):
         proofing_user = ProofingUser.from_dict(self.user_data)
         fetcher.private_db.save(proofing_user)
 
-        actual_update = fetcher.fetch_attrs(proofing_user.user_id)
-        # remove newly added created_ts
-        for nin in actual_update['$set']['nins']:
-            del nin['created_ts']
+        fetched = fetcher.fetch_attrs(proofing_user.user_id)
 
-        expected_update = {
+        expected = {
             '$set': {
                 "givenName": u"Testaren",
                 "surname": u"Testsson",
@@ -544,7 +535,9 @@ class AttributeFetcherNINProofingTests(AMTestCase):
                 ],
             },
         }
-        assert actual_update == expected_update, 'Fetched letter proofing data with appended attributes has unexpected data'
+        self.normalize_data(expected['$set']['nins'], fetched['$set']['nins'])
+
+        assert fetched == expected, 'Fetched letter proofing data with appended attributes has unexpected data'
 
 
 class AttributeFetcherEmailProofingTests(AMTestCase):
@@ -576,9 +569,14 @@ class AttributeFetcherEmailProofingTests(AMTestCase):
         proofing_user = ProofingUser.from_dict(self.user_data)
         fetcher.private_db.save(proofing_user)
 
+        fetched = fetcher.fetch_attrs(proofing_user.user_id)
+        expected = {'$set': {'mailAliases': [{'email': 'john@example.com', 'verified': True, 'primary': True,}],},}
+
+        self.normalize_data(expected['$set']['mailAliases'], fetched['$set']['mailAliases'])
+
         self.assertDictEqual(
-            fetcher.fetch_attrs(proofing_user.user_id),
-            {'$set': {'mailAliases': [{'email': 'john@example.com', 'verified': True, 'primary': True,}],},},
+            fetched,
+            expected,
         )
 
     def test_malicious_attributes(self):
@@ -616,9 +614,14 @@ class AttributeFetcherEmailProofingTests(AMTestCase):
         proofing_user = ProofingUser.from_dict(self.user_data)
         fetcher.private_db.save(proofing_user)
 
+        fetched = fetcher.fetch_attrs(proofing_user.user_id)
+        expected = {'$set': {'mailAliases': [{'email': 'john@example.com', 'verified': True, 'primary': True}],},}
+
+        self.normalize_data(expected['$set']['mailAliases'], fetched['$set']['mailAliases'])
+
         self.assertDictEqual(
-            fetcher.fetch_attrs(proofing_user.user_id),
-            {'$set': {'mailAliases': [{'email': 'john@example.com', 'verified': True, 'primary': True}],},},
+            fetched,
+            expected,
         )
 
 
@@ -633,8 +636,6 @@ class AttributeFetcherPhoneProofingTests(AMTestCase):
             proofing_user = ProofingUser.from_dict(userdoc)
             self.fetcher.private_db.save(proofing_user, check_sync=False)
 
-        self.maxDiff = None
-
     def tearDown(self):
         for fetcher in self.af_registry:
             self.af_registry[fetcher].private_db._drop_whole_collection()
@@ -648,11 +649,10 @@ class AttributeFetcherPhoneProofingTests(AMTestCase):
         proofing_user = ProofingUser.from_dict(self.user_data)
         self.fetcher.private_db.save(proofing_user)
         fetched = self.fetcher.fetch_attrs(proofing_user.user_id)
-        # remove newly added created_ts
-        for phone in fetched['$set']['phone']:
-            del phone['created_ts']
 
         expected = {'$set': {'phone': [{'verified': True, 'number': '+46700011336', 'primary': True}],},}
+
+        self.normalize_data(expected['$set']['phone'], fetched['$set']['phone'])
 
         assert expected == fetched, 'Unexpected data fetched by phone fetcher for existing user'
 
@@ -771,13 +771,10 @@ class AttributeFetcherSecurityTests(AMTestCase):
             '$unset': {'terminated': None},
         }
         fetched = self.fetcher.fetch_attrs(security_user.user_id)
-        # remove newly added created_ts
-        for pw in fetched['$set']['passwords']:
-            del pw['created_ts']
-        for nin in fetched['$set']['nins']:
-            del nin['created_ts']
-        for phone in fetched['$set']['phone']:
-            del phone['created_ts']
+
+        self.normalize_data(expected['$set']['passwords'], fetched['$set']['passwords'])
+        self.normalize_data(expected['$set']['nins'], fetched['$set']['nins'])
+        self.normalize_data(expected['$set']['phone'], fetched['$set']['phone'])
 
         assert fetched == expected, 'Wrong data fetched by the security fetcher'
 
@@ -798,13 +795,6 @@ class AttributeFetcherSecurityTests(AMTestCase):
         self.fetcher.private_db.save(security_user)
 
         fetched = self.fetcher.fetch_attrs(security_user.user_id)
-        # remove newly added created_ts
-        for pw in fetched['$set']['passwords']:
-            del pw['created_ts']
-        for nin in fetched['$set']['nins']:
-            del nin['created_ts']
-        for phone in fetched['$set']['phone']:
-            del phone['created_ts']
 
         expected = {
             '$set': {
@@ -820,6 +810,10 @@ class AttributeFetcherSecurityTests(AMTestCase):
             },
             '$unset': {'terminated': None},
         }
+        self.normalize_data(expected['$set']['passwords'], fetched['$set']['passwords'])
+        self.normalize_data(expected['$set']['nins'], fetched['$set']['nins'])
+        self.normalize_data(expected['$set']['phone'], fetched['$set']['phone'])
+
         assert fetched == expected, 'Wrong data fetched by security fetcher'
 
 
@@ -847,13 +841,6 @@ class AttributeFetcherResetPasswordTests(AMTestCase):
         self.fetcher.private_db.save(reset_password_user)
 
         fetched = self.fetcher.fetch_attrs(reset_password_user.user_id)
-        # remove newly added created_ts
-        for pw in fetched['$set']['passwords']:
-            del pw['created_ts']
-        for nin in fetched['$set']['nins']:
-            del nin['created_ts']
-        for phone in fetched['$set']['phone']:
-            del phone['created_ts']
 
         expected = {
             '$set': {
@@ -868,6 +855,10 @@ class AttributeFetcherResetPasswordTests(AMTestCase):
                 'phone': [{'number': '+46700011336', 'primary': True, 'verified': True}],
             }
         }
+        self.normalize_data(expected['$set']['passwords'], fetched['$set']['passwords'])
+        self.normalize_data(expected['$set']['nins'], fetched['$set']['nins'])
+        self.normalize_data(expected['$set']['phone'], fetched['$set']['phone'])
+
         assert fetched == expected, 'Wrong data fetched by reset password fetcher'
 
     def test_malicious_attributes(self):
@@ -887,13 +878,6 @@ class AttributeFetcherResetPasswordTests(AMTestCase):
         self.fetcher.private_db.save(reset_password_user)
 
         fetched = self.fetcher.fetch_attrs(reset_password_user.user_id)
-        # remove newly added created_ts
-        for pw in fetched['$set']['passwords']:
-            del pw['created_ts']
-        for nin in fetched['$set']['nins']:
-            del nin['created_ts']
-        for phone in fetched['$set']['phone']:
-            del phone['created_ts']
 
         expected = {
             '$set': {
@@ -908,6 +892,10 @@ class AttributeFetcherResetPasswordTests(AMTestCase):
                 'phone': [{'number': '+46700011336', 'primary': True, 'verified': True}],
             }
         }
+        self.normalize_data(expected['$set']['passwords'], fetched['$set']['passwords'])
+        self.normalize_data(expected['$set']['nins'], fetched['$set']['nins'])
+        self.normalize_data(expected['$set']['phone'], fetched['$set']['phone'])
+
         assert fetched == expected, 'Wrong data fetched by reset password fetcher'
 
 
@@ -934,14 +922,6 @@ class AttributeFetcherOrcidTests(AMTestCase):
         proofing_user = ProofingUser.from_dict(self.user_data)
         self.fetcher.private_db.save(proofing_user)
         fetched = self.fetcher.fetch_attrs(proofing_user.user_id)
-        # remove the datetimes from the response,
-        # that carry their own tzinfo object from bson
-        if 'created_ts' in fetched['$set']['orcid']:
-            fetched['$set']['orcid'].pop('created_ts')
-        if 'created_ts' in fetched['$set']['orcid']['oidc_authz']:
-            fetched['$set']['orcid']['oidc_authz'].pop('created_ts')
-        if 'created_ts' in fetched['$set']['orcid']['oidc_authz']['id_token']:
-            fetched['$set']['orcid']['oidc_authz']['id_token'].pop('created_ts')
 
         expected = {
             '$set': {
@@ -965,13 +945,14 @@ class AttributeFetcherOrcidTests(AMTestCase):
                     },
                     'given_name': 'Testaren',
                     'family_name': 'Testsson',
-                    'name': None,
                     'verified': True,
                     'id': 'orcid_unique_id',
                     'created_by': 'orcid',
                 }
             },
         }
+
+        self.normalize_data([expected['$set']], [fetched['$set']])
 
         assert expected == fetched
 

--- a/eduid_am/tests/test_signup.py
+++ b/eduid_am/tests/test_signup.py
@@ -93,7 +93,7 @@ class AttributeFetcherTests(AMTestCase):
 
         fetched = self.fetcher.fetch_attrs(user.user_id)
 
-        expected_passwords = [{'credential_id': u'123', 'is_generated': False, 'salt': u'456', }]
+        expected_passwords = [{'credential_id': u'123', 'is_generated': False, 'salt': u'456',}]
         self.normalize_data(fetched['$set']['passwords'], expected_passwords)
 
         expected_emails = [{'verified': True, 'primary': True, 'email': 'john@example.com'}]

--- a/eduid_am/tests/test_signup.py
+++ b/eduid_am/tests/test_signup.py
@@ -39,8 +39,7 @@ class AttributeFetcherTests(AMTestCase):
                 'salt': '$NDNv1H1$9c810d852430b62a9a7c6159d5d64c41c3831846f81b6799b54e1e8922f11545$32$32$',
             }
         ]
-        fetched_passwords, expected_passwords = self.normalize_data(fetched['$set']['passwords'], expected_passwords)
-        fetched['$set']['passwords'] = fetched_passwords
+        self.normalize_data(fetched['$set']['passwords'], expected_passwords)
 
         expected_emails = [
             {
@@ -53,8 +52,7 @@ class AttributeFetcherTests(AMTestCase):
             {'email': 'johnsmith2@example.com', 'primary': False, 'verified': True},
             {'email': 'johnsmith3@example.com', 'primary': False, 'verified': False},
         ]
-        fetched_emails, expected_emails = self.normalize_data(fetched['$set']['mailAliases'], expected_emails)
-        fetched['$set']['mailAliases'] = fetched_emails
+        self.normalize_data(fetched['$set']['mailAliases'], expected_emails)
 
         expected = {
             '$set': {
@@ -96,12 +94,10 @@ class AttributeFetcherTests(AMTestCase):
         fetched = self.fetcher.fetch_attrs(user.user_id)
 
         expected_passwords = [{'credential_id': u'123', 'is_generated': False, 'salt': u'456', }]
-        fetched_passwords, expected_passwords = self.normalize_data(fetched['$set']['passwords'], expected_passwords)
-        fetched['$set']['passwords'] = fetched_passwords
+        self.normalize_data(fetched['$set']['passwords'], expected_passwords)
 
         expected_emails = [{'verified': True, 'primary': True, 'email': 'john@example.com'}]
-        fetched_emails, expected_emails = self.normalize_data(fetched['$set']['mailAliases'], expected_emails)
-        fetched['$set']['mailAliases'] = fetched_emails
+        self.normalize_data(fetched['$set']['mailAliases'], expected_emails)
 
         expected = {
             '$set': {

--- a/eduid_am/tests/test_signup.py
+++ b/eduid_am/tests/test_signup.py
@@ -62,7 +62,7 @@ class AttributeFetcherTests(AMTestCase):
             }
         }
 
-        assert expected == fetched
+        assert fetched == expected
 
     def test_existing_user(self):
         user_data = deepcopy(USER_DATA)

--- a/eduid_am/tests/test_signup.py
+++ b/eduid_am/tests/test_signup.py
@@ -29,39 +29,42 @@ class AttributeFetcherTests(AMTestCase):
             self.fetcher.fetch_attrs(bson.ObjectId('000000000000000000000000'))
 
     def test_existing_user_from_db(self):
-        self.maxDiff = None
+        fetched = self.fetcher.fetch_attrs(bson.ObjectId(M['_id']))
+
+        expected_passwords = [
+            {
+                'created_by': 'signup',
+                'credential_id': '112345678901234567890123',
+                'is_generated': False,
+                'salt': '$NDNv1H1$9c810d852430b62a9a7c6159d5d64c41c3831846f81b6799b54e1e8922f11545$32$32$',
+            }
+        ]
+        fetched_passwords, expected_passwords = self.normalize_data(fetched['$set']['passwords'], expected_passwords)
+        fetched['$set']['passwords'] = fetched_passwords
+
+        expected_emails = [
+            {
+                'created_by': 'signup',
+                'email': 'johnsmith@example.com',
+                'primary': True,
+                'verified': True,
+                'verified_by': 'signup',
+            },
+            {'email': 'johnsmith2@example.com', 'primary': False, 'verified': True},
+            {'email': 'johnsmith3@example.com', 'primary': False, 'verified': False},
+        ]
+        fetched_emails, expected_emails = self.normalize_data(fetched['$set']['mailAliases'], expected_emails)
+        fetched['$set']['mailAliases'] = fetched_emails
+
         expected = {
             '$set': {
                 'eduPersonPrincipalName': 'hubba-bubba',
-                'mailAliases': [
-                    {
-                        'created_by': 'signup',
-                        'email': 'johnsmith@example.com',
-                        'primary': True,
-                        'verified': True,
-                        'verified_by': 'signup',
-                    },
-                    {'email': 'johnsmith2@example.com', 'primary': False, 'verified': True},
-                    {'email': 'johnsmith3@example.com', 'primary': False, 'verified': False},
-                ],
-                'passwords': [
-                    {
-                        'created_by': 'signup',
-                        'credential_id': '112345678901234567890123',
-                        'is_generated': False,
-                        'salt': '$NDNv1H1$9c810d852430b62a9a7c6159d5d64c41c3831846f81b6799b54e1e8922f11545$32$32$',
-                    }
-                ],
+                'mailAliases': expected_emails,
+                'passwords': expected_passwords,
             }
         }
-        res = self.fetcher.fetch_attrs(bson.ObjectId(M['_id']))
-        # remove the datetimes from the response,
-        # that carry their own tzinfo object from bson
-        del res['$set']['mailAliases'][0]['created_ts']
-        del res['$set']['mailAliases'][0]['verified_ts']
-        del res['$set']['passwords'][0]['created_ts']
 
-        assert res == expected
+        assert expected == fetched
 
     def test_existing_user(self):
         user_data = deepcopy(USER_DATA)
@@ -91,17 +94,24 @@ class AttributeFetcherTests(AMTestCase):
         self.fetcher.private_db.save(user)
 
         fetched = self.fetcher.fetch_attrs(user.user_id)
-        for pw in fetched['$set']['passwords']:
-            del pw['created_ts']
+
+        expected_passwords = [{'credential_id': u'123', 'is_generated': False, 'salt': u'456', }]
+        fetched_passwords, expected_passwords = self.normalize_data(fetched['$set']['passwords'], expected_passwords)
+        fetched['$set']['passwords'] = fetched_passwords
+
+        expected_emails = [{'verified': True, 'primary': True, 'email': 'john@example.com'}]
+        fetched_emails, expected_emails = self.normalize_data(fetched['$set']['mailAliases'], expected_emails)
+        fetched['$set']['mailAliases'] = fetched_emails
 
         expected = {
             '$set': {
                 'eduPersonPrincipalName': 'test-test',
-                'mailAliases': [{'verified': True, 'primary': True, 'email': 'john@example.com'}],
-                'passwords': [{'credential_id': u'123', 'is_generated': False, 'salt': u'456',}],
+                'mailAliases': expected_emails,
+                'passwords': expected_passwords,
             }
         }
-        assert fetched == expected, 'Wronf data fetched by signup fetcher'
+
+        assert fetched == expected, 'Wrong data fetched by signup fetcher'
 
     def test_malicious_attributes(self):
         user_data = deepcopy(USER_DATA)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-eduid_common[worker]>=0.6.2
-eduid_userdb>=0.4.18
+eduid_common[worker]>=0.7.9
+eduid_userdb>=0.5.0
 python-dateutil>=2.1
 vine<5.0.0a1  # Version mismatch problem
 kombu==4.5.0  # Stable release until celery[redis]==4.4.*

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-eduid_common[worker]>=0.7.9
+eduid_common[worker]>=0.7.11
 eduid_userdb>=0.5.0
 python-dateutil>=2.1
 vine<5.0.0a1  # Version mismatch problem

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ README = 'eduID Attribute Manager'
 if os.path.exists(README_fn):
     README = open(README_fn).read()
 
-version = '0.7.7'
+version = '0.7.8'
 
 here = os.path.abspath(os.path.dirname(__file__))
 install_requires = [x for x in open(os.path.join(here, 'requirements.txt')).read().split('\n') if len(x) > 0]


### PR DESCRIPTION
Moving Element to a dataclass:
* remove old_userdb_format parameter.
* Normalize data in dicts in the tests, wrt timestamps